### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: main
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/sripwoud/cza/security/code-scanning/1](https://github.com/sripwoud/cza/security/code-scanning/1)

To fix this issue, add an explicit `permissions` block at the workflow level (before `jobs:`), with the least privileges needed. For jobs that only read repository content (such as running checks, tests, or reading changed files), set `contents: read`. The `release` job already defines its required permissions, so it will not inherit the workflow root permissions. No existing job changes functionality or requires write access except `release`.  
**Steps:**  
- Insert the following block after the workflow name and before the `on:` trigger, i.e., between lines 1 and 3:
  ```yaml
  permissions:
    contents: read
  ```
- This minimizes GITHUB_TOKEN privileges for all jobs except those (like `release`) that declare their own `permissions`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
