### PR TITLE
feat!: release stable v1.0.0

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cza"
-version = "0.1.0-alpha.5"
+version = "1.0.0"
 authors = ["sripwoud"]
 categories = ["command-line-utilities", "development-tools"]
 edition.workspace = true


### PR DESCRIPTION
BREAKING CHANGE: Transitioning from alpha prerelease to stable v1.0.0.
This marks the CLI as production-ready with a stable API.
