### PR TITLE
feat!: add structured verbose logging with config integration (#14)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,15 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1.0"
+assert_cmd = "2.0"
 cargo-generate = "0.21"
 clap = { version = "4.5.29", features = ["derive"] }
 console = "0.15"
 dirs = "6.0"
-serde = { version = "1.0", features = ["derive"] }
-toml = "0.8"
-
-# Test dependencies
-assert_cmd = "2.0"
 env_logger = "0.11"
+log = "0.4"
 predicates = "3.0"
+serde = { version = "1.0", features = ["derive"] }
 snapbox = "0.6"
 tempfile = "3.8"
+toml = "0.8"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,8 @@ cargo-generate.workspace = true
 clap.workspace = true
 console.workspace = true
 dirs.workspace = true
+env_logger.workspace = true
+log.workspace = true
 serde.workspace = true
 toml.workspace = true
 

--- a/cli/src/cmd/config.rs
+++ b/cli/src/cmd/config.rs
@@ -3,14 +3,15 @@ use crate::config::Config;
 use crate::output;
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
+use log::debug;
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct ConfigArgs {
     #[command(subcommand)]
     pub command: Option<ConfigSubcommand>,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum ConfigSubcommand {
     /// Set a configuration value
     Set {
@@ -38,8 +39,11 @@ impl Execute for ConfigCommand {
     type Args = ConfigArgs;
 
     fn run(&self, args: &Self::Args) -> Result<()> {
+        debug!("Starting config command: {:#?}", args.command);
+
         match &args.command {
             Some(ConfigSubcommand::Set { key, value }) => {
+                debug!("Setting config key: {} = {}", key, value);
                 let mut config = Config::load()?;
                 config
                     .set(key, value)

--- a/cli/src/cmd/list.rs
+++ b/cli/src/cmd/list.rs
@@ -2,8 +2,9 @@ use super::Execute;
 use crate::{output, template};
 use anyhow::Result;
 use clap::Args;
+use log::{debug, warn};
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct ListArgs {
     /// Show detailed information about templates
     #[arg(long)]
@@ -16,10 +17,15 @@ impl Execute for ListCommand {
     type Args = ListArgs;
 
     fn run(&self, args: &Self::Args) -> Result<()> {
+        debug!("Starting list command with detailed: {}", args.detailed);
+
         // Load embedded template registry
+        debug!("Loading embedded template registry");
         let registry = template::load_template_registry()?;
+        debug!("Found {} templates", registry.templates.len());
 
         if registry.templates.is_empty() {
+            warn!("No templates available in registry");
             output::warning("No templates available.");
             return Ok(());
         }

--- a/cli/src/cmd/update.rs
+++ b/cli/src/cmd/update.rs
@@ -1,8 +1,9 @@
 use super::Execute;
 use anyhow::Result;
 use clap::Args;
+use log::debug;
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct UpdateArgs;
 
 pub struct UpdateCommand;
@@ -11,7 +12,9 @@ impl Execute for UpdateCommand {
     type Args = UpdateArgs;
 
     fn run(&self, _args: &Self::Args) -> Result<()> {
+        debug!("Starting update command");
         println!("Updating the CLI tool to the latest version...");
+        debug!("Update feature is not yet implemented");
         // Implement the logic to update the CLI tool
         Ok(())
     }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -9,7 +9,7 @@ use crate::cmd::{config::ConfigArgs, list::ListArgs, new::NewArgs, update::Updat
 use clap::{Parser, Subcommand};
 
 /// CLI tool to create zero-knowledge applications
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[command(
     name = "create-zk-app",
     version = "1.0",
@@ -21,7 +21,7 @@ pub struct Cli {
     pub command: Command,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum Command {
     /// Create a new ZK application project
     New(NewArgs),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,18 +1,58 @@
+use anyhow::Result;
 use clap::Parser;
 use cza::{
     cmd::{
         config::ConfigCommand, list::ListCommand, new::NewCommand, update::UpdateCommand, Execute,
     },
+    config::Config,
     Cli, Command,
 };
+use log::debug;
+
+fn init_logging(cli_verbose: Option<bool>) -> Result<()> {
+    // Don't override if RUST_LOG is already set by user
+    if std::env::var("RUST_LOG").is_err() {
+        // Load config to get default verbose setting
+        let config = Config::load().unwrap_or_default();
+
+        // Determine level: CLI flag > config > default
+        let verbose = cli_verbose.unwrap_or(config.development.verbose);
+        let level = if verbose { "debug" } else { "info" };
+
+        std::env::set_var("RUST_LOG", format!("cza={}", level));
+    }
+
+    env_logger::init();
+    Ok(())
+}
 
 fn main() {
     let cli = Cli::parse();
 
+    // Initialize logging - for now we don't have CLI verbose flags, so pass None
+    if let Err(e) = init_logging(None) {
+        eprintln!("Failed to initialize logging: {}", e);
+        std::process::exit(1);
+    }
+
+    debug!("CLI arguments parsed: {:#?}", cli);
+
     match &cli.command {
-        Command::New(args) => NewCommand.execute(args),
-        Command::List(args) => ListCommand.execute(args),
-        Command::Config(args) => ConfigCommand.execute(args),
-        Command::Update(args) => UpdateCommand.execute(args),
+        Command::New(args) => {
+            debug!("Executing new command");
+            NewCommand.execute(args)
+        }
+        Command::List(args) => {
+            debug!("Executing list command");
+            ListCommand.execute(args)
+        }
+        Command::Config(args) => {
+            debug!("Executing config command");
+            ConfigCommand.execute(args)
+        }
+        Command::Update(args) => {
+            debug!("Executing update command");
+            UpdateCommand.execute(args)
+        }
     }
 }


### PR DESCRIPTION
Trigger stable version release

- Add log and env_logger dependencies for structured logging
- Initialize logging based on development.verbose config setting
- Replace ad-hoc verbose checks with debug/info/warn log levels
- Support RUST_LOG environment variable override
- Add debug logging throughout all CLI commands

This allows users to control verbosity via config:
  cza config set development.verbose true   # Enable debug logs
  cza config set development.verbose false  # Only info/warn/error
  RUST_LOG=debug cza list                   # Override via env var
