### PR TITLE
chore: update CLI metadata in lib.rs

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,13 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(update)* implement self-updating CLI capability ([#24](https://github.com/sripwoud/cza/pull/24))
-- *(output)* integrate development.color config setting ([#21](https://github.com/sripwoud/cza/pull/21))
-- *(new)* [**breaking**] integrate config settings into new command ([#20](https://github.com/sripwoud/cza/pull/20))
+- _(update)_ implement self-updating CLI capability ([#24](https://github.com/sripwoud/cza/pull/24))
+- _(output)_ integrate development.color config setting ([#21](https://github.com/sripwoud/cza/pull/21))
+- _(new)_ [**breaking**] integrate config settings into new command ([#20](https://github.com/sripwoud/cza/pull/20))
 
 ### Fixed
 
-- *(cli)* restructure NewArgs to resolve clap validation error ([#22](https://github.com/sripwoud/cza/pull/22))
+- _(cli)_ restructure NewArgs to resolve clap validation error ([#22](https://github.com/sripwoud/cza/pull/22))
 
 ### Other
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -11,10 +11,10 @@ use clap::{Parser, Subcommand};
 /// CLI tool to create zero-knowledge applications
 #[derive(Parser, Debug)]
 #[command(
-    name = "create-zk-app",
-    version = "1.0",
-    author = "Your Name <your.email@example.com>",
-    about = "CLI tool to create zero-knowledge applications"
+    name = "cza",
+    version,
+    author = "sripwoud",
+    about = "CLI tool for scaffolding zero-knowledge application projects"
 )]
 pub struct Cli {
     #[command(subcommand)]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -12,7 +12,7 @@ fn test_version_output() {
     cmd.arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::starts_with("create-zk-app "));
+        .stdout(predicate::str::starts_with("cza "));
 }
 
 #[test]
@@ -22,7 +22,7 @@ fn test_help_output() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "CLI tool to create zero-knowledge",
+            "CLI tool for scaffolding zero-knowledge application",
         ))
         .stdout(predicate::str::contains("new"))
         .stdout(predicate::str::contains("list"));


### PR DESCRIPTION
## Summary
- Updated CLI name from 'create-zk-app' to 'cza'
- Now uses automatic version from Cargo.toml
- Updated author to 'sripwoud' 
- Updated about text to match Cargo.toml description
- Fixed integration tests to match new CLI output

## Test plan
- [x] All tests pass (`mise run t`)
- [x] Linting passes (`mise run l`)
- [x] CLI help and version commands show correct metadata