### PR TITLE
feat: add --no-git flag to skip git initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ cza list --detailed
 # Create a project with a specific template
 cza new noir-vite awesome-zk-project
 
+# Skip git initialization
+cza new noir-vite awesome-zk-project --no-git
+
 # The generated project includes:
 # ├── circuit/          # Noir ZK circuit code
 # ├── web/              # Vite React frontend

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -129,3 +129,12 @@ fn test_update_command_help() {
             "Update the CLI tool to the latest version",
         ));
 }
+
+#[test]
+fn test_new_command_no_git_flag() {
+    let mut cmd = Command::cargo_bin("cza").unwrap();
+    cmd.args(["new", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--no-git"));
+}


### PR DESCRIPTION
## Summary
- Adds `--no-git` flag to `cza new` command to skip git initialization
- Flag overrides `config.user.git_init` setting
- Git hooks installation is now conditional on git being initialized

## Changes
- **CLI Args**: Added `no_git: bool` field to `NewArgs` struct
- **Logic**: Modified `run_post_generation_setup` to respect `--no-git` flag
- **Git Hooks**: Skip `hk install` when git is not initialized
- **Tests**: 3 new unit tests covering flag behavior and config interaction
- **Integration Test**: Verify `--no-git` flag appears in help text
- **Docs**: Added usage example to README.md

## Test Results
✅ All 111 tests pass
✅ Linting passes (clippy)
✅ Coverage: 88.52% overall

## Usage Example
```bash
# Skip git initialization
cza new noir-vite my-project --no-git
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)