### PR TITLE
docs: add comprehensive rustdoc documentation

### DIFF
--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -1,3 +1,14 @@
+//! Command implementations for the CLI
+//!
+//! This module contains all command implementations that can be executed via the CLI:
+//!
+//! - [`new`] - Create new ZK application projects from templates
+//! - [`list`] - List available templates and frameworks
+//! - [`config`] - Configure global CLI settings
+//! - [`update`] - Self-update the CLI tool
+//!
+//! All commands implement the [`Execute`] trait for consistent execution and error handling.
+
 use crate::output;
 use anyhow::Result;
 
@@ -6,11 +17,15 @@ pub mod list;
 pub mod new;
 pub mod update;
 
+/// Trait for command execution with standardized error handling
 pub trait Execute {
+    /// Associated type for command arguments
     type Args;
 
+    /// Execute the command with the given arguments
     fn run(&self, args: &Self::Args) -> Result<()>;
 
+    /// Execute the command and handle errors consistently
     fn execute(&self, args: &Self::Args) {
         if let Err(e) = self.run(args) {
             output::format_error(&e);

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,3 +1,26 @@
+//! Configuration management for cza
+//!
+//! This module handles loading, saving, and managing user configuration stored in `~/.config/cza/config.toml`.
+//!
+//! ## Configuration Structure
+//!
+//! The configuration is divided into three main sections:
+//!
+//! - [`UserConfig`] - User preferences (author, email, default template, git initialization)
+//! - [`DevelopmentConfig`] - Development settings (verbose logging, color output, overwrite confirmation)
+//! - [`PostGenerationConfig`] - Post-generation behavior (auto-install deps, auto-setup hooks, open editor)
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use cza::config::Config;
+//!
+//! let mut config = Config::load()?;
+//! config.set("user.author", "John Doe")?;
+//! config.save()?;
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,3 +1,87 @@
+//! # create-zk-app (cza)
+//!
+//! A CLI tool for scaffolding zero-knowledge application projects with modern development tooling and best practices built-in.
+//!
+//! ## What is cza?
+//!
+//! **cza** (create-zk-app) is like `create-react-app` but for zero-knowledge applications. It provides curated, opinionated project templates that combine ZK frameworks with modern frontend stacks, complete with development tooling and CI/CD setup.
+//!
+//! ## Features
+//!
+//! - **🚀 Quick Project Setup** - Generate complete ZK projects in seconds
+//! - **🎯 Opinionated Templates** - Pre-configured with best practices and modern tooling
+//! - **🔧 Development Ready** - Includes mise, git hooks, formatting, linting, and CI/CD
+//! - **🌐 Full Stack** - ZK circuits + modern frontend (Vite + TanStack)
+//! - **🛠️ Smart Setup** - Automatic dependency installation and project initialization
+//!
+//! ## Quick Start
+//!
+//! ### Installation
+//!
+//! Install via cargo:
+//!
+//! ```bash
+//! cargo install cza
+//! ```
+//!
+//! Or use npx without installation:
+//!
+//! ```bash
+//! npx create-zk-app
+//! ```
+//!
+//! ### Usage
+//!
+//! List available templates:
+//!
+//! ```bash
+//! cza list
+//! ```
+//!
+//! Create a new project:
+//!
+//! ```bash
+//! cza new noir-vite my-zk-app
+//! cd my-zk-app
+//! mise run dev
+//! ```
+//!
+//! ## Available Templates
+//!
+//! Templates are hosted at [cza-templates](https://github.com/sripwoud/cza-templates).
+//!
+//! | Template | ZK Framework | Frontend |
+//! |----------|--------------|----------|
+//! | `cairo-vite` | [Cairo](https://www.cairo-lang.org) | [Vite](https://vitejs.dev/) + [React](https://react.dev/) + [TanStack](https://tanstack.com/) |
+//! | `noir-vite` | [Noir](https://noir-lang.org/) | [Vite](https://vitejs.dev/) + [React](https://react.dev/) + [TanStack](https://tanstack.com/) |
+//!
+//! More templates coming soon: Risc0, o1js, and more!
+//!
+//! ## How It Works
+//!
+//! **cza** uses:
+//!
+//! - **[cargo-generate](https://github.com/cargo-generate/cargo-generate)** for template processing
+//! - **Template repositories** hosted on GitHub with Handlebars variable substitution
+//! - **Automatic setup** via post-generation scripts that install tools and configure the environment
+//! - **Embedded registry** for fast template discovery and listing
+//!
+//! Each template is a complete, working project that includes:
+//!
+//! - ZK framework setup (Noir, Cairo, etc.)
+//! - Modern frontend stack (Vite + TanStack Router/Query/Form)
+//! - Development tooling (mise, dprint, biome, convco)
+//! - Git hooks and CI/CD workflows
+//! - Ready-to-use examples and documentation
+//!
+//! ## Modules
+//!
+//! - [`cmd`] - Command implementations (new, list, config, update)
+//! - [`config`] - Configuration management
+//! - [`output`] - Formatted terminal output
+//! - [`template`] - Template registry and validation
+//! - [`utils`] - Utility functions
+
 pub mod cmd;
 pub mod config;
 pub mod output;
@@ -20,6 +104,7 @@ pub struct Cli {
     pub command: Command,
 }
 
+/// Available commands for the CLI
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Create a new ZK application project

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -1,3 +1,33 @@
+//! Template registry and validation
+//!
+//! This module manages the embedded template registry loaded from `templates.toml`.
+//! It provides functionality to:
+//!
+//! - Load available templates from the embedded registry
+//! - Validate template configuration
+//! - Check system prerequisites (git availability)
+//!
+//! ## Template Structure
+//!
+//! Each template in the registry contains:
+//! - Name and description
+//! - Git repository URL
+//! - Subfolder path within the repository
+//! - Associated ZK frameworks
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use cza::template::{load_template_registry, validate_template};
+//!
+//! let registry = load_template_registry()?;
+//! if let Some(template) = registry.templates.get("noir-vite") {
+//!     validate_template(template)?;
+//!     println!("Template {} is valid", template.name);
+//! }
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
 use anyhow::{anyhow, Result};
 use log::debug;
 use serde::Deserialize;
@@ -7,16 +37,22 @@ use std::process::Command;
 /// Template registry containing all available templates
 #[derive(Deserialize)]
 pub struct TemplateRegistry {
+    /// Map of template keys to template information
     pub templates: HashMap<String, TemplateInfo>,
 }
 
 /// Information about a specific template
 #[derive(Deserialize)]
 pub struct TemplateInfo {
+    /// Display name of the template
     pub name: String,
+    /// Description of what the template provides
     pub description: String,
+    /// Git repository URL
     pub repository: String,
+    /// Subfolder path within the repository
     pub subfolder: String,
+    /// ZK frameworks included in the template
     pub frameworks: Vec<String>,
 }
 

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,3 +1,13 @@
+//! Utility functions for command execution
+//!
+//! This module provides helper functions for:
+//!
+//! - Running system commands with standardized logging and error handling
+//! - Retrieving git configuration values
+//! - Running post-generation commands with user-friendly output
+//!
+//! These utilities are used throughout the CLI for consistent command execution and output formatting.
+
 use crate::output;
 use log::debug;
 use std::path::Path;


### PR DESCRIPTION
## Summary

Add comprehensive rustdoc documentation to make the crate documentation available on docs.rs without requiring users to visit GitHub.

- Crate-level overview with features, quick start, and usage examples
- Module-level documentation for `cmd`, `config`, `template`, and `utils`
- Enhanced public API documentation for structs and enums
- Code examples demonstrating configuration and template usage

## Test plan

- [x] Built docs locally with `cargo doc --no-deps --open`
- [x] Verified all documentation renders correctly
- [x] Confirmed code examples compile
- [x] Checked navigation between modules works