### PR TITLE
feat: add --dry-run flag to new command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Download pre-built binaries for your platform from the [latest release](https://
 # List available templates
 cza list
 
+# Preview a template structure (dry-run)
+cza new noir-vite my-zk-app --dry-run
+
 # Create a new Noir + Vite project
 cza new noir-vite my-zk-app
 


### PR DESCRIPTION
## Summary
- Add optional `--dry-run` flag to `new` command that previews template structure without creating files
- Shows project name, template info, expected directory structure, and post-generation steps
- Useful for users to preview what will be created before committing

## Changes
- Added `dry_run: bool` field to `NewArgs` struct
- Implemented `preview_template()` method that displays preview information
- Updated all existing tests to include `dry_run: false`
- Added 2 new unit tests for dry-run behavior
- Updated README with dry-run usage example

## Test Plan
- ✅ All 113 tests passing
- ✅ New tests verify dry-run flag behavior
- ✅ Linter passing (cargo clippy)
- ✅ Formatter passing (dprint fmt)

## Testing the Release Workflow
This small feature change triggers a `feat:` commit which will test the unified release workflow (PR #36):
1. release-plz detects the conventional commit
2. Creates a version bump PR with CHANGELOG updates
3. On merge, creates git tag
4. cargo-dist builds binaries and creates GitHub release
5. Publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)