### PR TITLE
ci: use fine-grained PAT for release-plz to trigger cargo-dist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,5 +107,5 @@ jobs:
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Problem

When release-plz creates tags using `GITHUB_TOKEN`, it doesn't trigger the `v-release.yml` workflow due to GitHub's security feature that prevents recursive workflow runs.

Result: v2.3.0 tag was created but no GitHub release was generated.

## Solution

Use a fine-grained Personal Access Token (`GH_PAT`) with:
- **Contents**: Read and write
- **Pull requests**: Read and write

This allows tags created by release-plz to trigger the cargo-dist workflow.

## Changes

- Updated `.github/workflows/main.yml` to use `secrets.GH_PAT` instead of `secrets.GITHUB_TOKEN` in the release-plz step

## Testing

After merge:
1. Next `feat:` commit will trigger release-plz
2. release-plz creates release PR with tag
3. Tag created with `GH_PAT` will trigger `v-release.yml`
4. cargo-dist builds binaries and creates GitHub release with changelog

## References

- [release-plz GitHub token docs](https://release-plz.dev/docs/github/token)
- GitHub Actions: tokens from workflows don't trigger other workflows