### PR TITLE
chore: release v2.4.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0](https://github.com/sripwoud/cza/compare/v2.3.0...v2.4.0) - 2025-09-30
+
+### Added
+
+- add --json flag to list command ([#42](https://github.com/sripwoud/cza/pull/42))
+
 ## [2.3.0](https://github.com/sripwoud/cza/compare/v2.2.1...v2.3.0) - 2025-09-30
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cza"
-version = "2.3.0"
+version = "2.4.0"
 authors = ["sripwoud"]
 categories = ["command-line-utilities", "development-tools"]
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `cza`: 2.3.0 -> 2.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.4.0](https://github.com/sripwoud/cza/compare/v2.3.0...v2.4.0) - 2025-09-30

### Added

- add --json flag to list command ([#42](https://github.com/sripwoud/cza/pull/42))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).