### PR TITLE
chore: configure cargo-dist to handle publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ targets = [
 ]
 # npm package configuration
 npm-package = "create-zk-app"
-# Enable npm publishing
-publish-jobs = ["npm"]
+# Enable npm and crates.io publishing
+publish-jobs = ["npm", "cargo"]
 # npm scope (optional, but commonly used for organizations)
 # npm-scope = "@sripwoud"
 # Tag namespace for matching release tags

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,8 @@
 release_commits = "^(feat|fix|perf|refactor)[:(]"
 # Disable GitHub release creation - let cargo-dist handle it
 git_release_enable = false
+# Disable crates.io publishing - let cargo-dist handle it
+publish = false
 
 [[package]]
 name = "cza"


### PR DESCRIPTION
## Summary
- Disable crates.io publishing in release-plz
- Enable cargo publishing in cargo-dist publish-jobs

## Changes
This reconfigures the release workflow to cleanly separate responsibilities:
- **release-plz**: handles semantic versioning, PR creation, and git tagging only
- **cargo-dist**: handles building assets, creating GitHub releases, and publishing to both crates.io and npm

## Test plan
- [ ] Verify release-plz no longer publishes to crates.io
- [ ] Verify cargo-dist publishes to both crates.io and npm when triggered by a version tag
- [ ] Confirm GitHub releases are created by cargo-dist with proper assets