### PR TITLE
ci: split release-plz into separate workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,8 +104,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run release-plz
+      - name: Run release-plz release-pr
         uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -306,15 +306,39 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  publish-crates:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz release
+        uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   announce:
     needs:
       - plan
       - host
       - publish-npm
+      - publish-crates
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') && (needs.publish-crates.result == 'skipped' || needs.publish-crates.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Split release-plz into two separate commands to synchronize crates.io and npm publishing.

## Changes

### main.yml (push to main)
- Only runs `release-plz release-pr` command
- Removed `CARGO_REGISTRY_TOKEN` 
- Creates release PR with version bumps and changelog
- Does NOT publish anything

### v-release.yml (tag push)
- Added `publish-crates` job that runs `release-plz release`
- Both `publish-npm` and `publish-crates` run in parallel after cargo-dist builds
- All publishing (crates.io + npm + GH release) happens synchronously on tag push

## Workflow
1. Push to `main` → release-plz creates release PR
2. User merges release PR → release-plz creates git tag
3. Tag push triggers `v-release.yml` → cargo-dist builds assets + publishes npm + publishes crates.io

## Benefits
- **Synchronized publishing**: crates.io and npm publish at the same time
- **Clean separation**: PR creation vs publishing are separate concerns
- **Control**: User explicitly approves releases by merging the PR