### PR TITLE
revert: restore release-plz to run both commands on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,9 +104,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run release-plz release-pr
+      - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
-        with:
-          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -306,39 +306,15 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  publish-crates:
-    needs:
-      - plan
-      - host
-    runs-on: "ubuntu-22.04"
-    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Run release-plz release
-        uses: MarcoIeni/release-plz-action@v0.5
-        with:
-          command: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
   announce:
     needs:
       - plan
       - host
       - publish-npm
-      - publish-crates
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') && (needs.publish-crates.result == 'skipped' || needs.publish-crates.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Reverts commit 9b82202 (ci: split release-plz into separate workflows).

## Problem with Split Approach
The split approach doesn't work due to a chicken-and-egg problem:
- `release-plz release` creates the git tag **AND** publishes to crates.io atomically
- cargo-dist requires a tag to exist before it can be triggered
- Cannot run `release-plz release` in the tag-triggered workflow because there's no tag yet

## Changes
**main.yml:**
- Restored default behavior (runs both `release-plz release-pr` and `release-plz release`)
- Re-added `CARGO_REGISTRY_TOKEN` environment variable
- Removed explicit `command: release-pr` specification

**v-release.yml:**
- Removed `publish-crates` job (crates.io is already published by release-plz on main)
- Removed `publish-crates` from announce job dependencies

## Workflow
1. Feature push to main → release-plz creates/updates release PR (no publishing)
2. Merge release PR to main → release-plz creates tag + publishes to crates.io
3. Tag push triggers cargo-dist → publishes to npm + creates GitHub release

## Result
- crates.io and npm publishing are **not** perfectly synchronized
- crates.io publishes first (~30s), npm follows (~1-2min later)
- Close enough for practical purposes